### PR TITLE
syntax highlighting for the icons CSS on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ The SASS files will be found in the `/scss` directory. For further details refer
 
 Modus icons are required for some of the components like DataTable, FileUploadDropZone, TablePagination and TreeView. To use the icons, include the following:
 
-> `<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">`
-
-> `<link rel="stylesheet" href="https://modus.trimble.com/assets/0.5.1/fonts/modus-icons.css">`
+```html
+<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+<link rel="stylesheet" href="https://modus.trimble.com/assets/0.5.1/fonts/modus-icons.css">
+```
 
 ## Build Package
 


### PR DESCRIPTION
## Description

Adds syntax highlighting to the HTML tags on the README

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

VS Code and GitHub displays this a bit nicer

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
