### PR TITLE
Modus React DataTable - Fix UI Inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fixes [bug](https://github.com/trimble-oss/modus-react-bootstrap/issues/114)
+
 ## v1.1.4 - 2022-08-19
 
 - Upgraded to [Modus Bootstrap v1.5.4](https://www.npmjs.com/package/@trimbleinc/modus-bootstrap), check the [Modus Bootstrap Release notes](https://modus-bootstrap.trimble.com/changelog/) for more details.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint-js": "eslint --ext tsx --ext ts src && tsc --noEmit",
     "build-docs": "cd docs && yarn run build",
     "clean-docs": "yarn --cwd docs clean",
-    "deploy-docs": "yarn run bootstrap && yarn run clean-docs && yarn run lint-docs && yarn run build-docs",
+    "deploy-docs": "yarn run bootstrap && yarn run build && yarn run clean-docs && yarn run lint-docs && yarn run build-docs",
     "lint-css-docs": "stylelint \"docs/src/assets/css/*.scss\"  --fix",
     "lint-docs": "yarn run lint-js-docs && yarn run lint-css-docs",
     "lint-js-docs": "eslint docs/src/**/*.{js,jsx,ts,tsx,json}",

--- a/scss/components/_data-table.scss
+++ b/scss/components/_data-table.scss
@@ -68,14 +68,22 @@
       &.drop-block {
         box-shadow: inset 2px 0 0 0 $col_red;
       }
+    }
 
-      &.draggable {
-        padding-left: 0;
+    &:not(.resizing) {
+      th.draggable > .th-content {
+        cursor: grab;
+      }
 
-        .th-content {
-          cursor: grab !important;
-          padding-left: 1rem;
-        }
+      th .modus-icons.material-icons.sorted,
+      th .modus-icons.material-icons.unsorted {
+        cursor: pointer;
+      }
+    }
+
+    &.resizing {
+      th {
+        cursor: ew-resize !important;
       }
     }
 
@@ -83,7 +91,6 @@
     th .modus-icons.material-icons.unsorted {
       vertical-align: text-bottom;
       font-size: 1rem;
-      cursor: pointer !important;
     }
 
     th .modus-icons.material-icons.unsorted {
@@ -198,4 +205,11 @@
   .mrb-table-pagination {
     border-top: 1px solid $table-border-color;
   }
+}
+
+.context-menu:not(.list-group-condensed)
+  .custom-checkbox
+  .custom-control-label {
+  line-height: 2;
+  font-size: inherit;
 }

--- a/src/ContextMenu.tsx
+++ b/src/ContextMenu.tsx
@@ -1,13 +1,16 @@
 import React, { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import classNames from 'classnames';
 import Dropdown from './Dropdown';
 import { ContextMenuItem } from './types';
 
-interface ContextMenuProps extends Omit<React.HTMLProps<HTMLDivElement>, 'as'> {
+interface ContextMenuProps
+  extends Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'size'> {
   menu: ContextMenuItem[];
   anchorPointX: string | number;
   anchorPointY: string | number;
+  size?: string;
   onClose: (...args: any[]) => void;
 }
 
@@ -22,13 +25,6 @@ const ContextMenuStyled = styled.div`
   .list-group-item + .dropdown-menu {
     padding: 0;
   }
-
-  span,
-  div,
-  label,
-  li {
-    font-size: 0.875rem;
-  }
 `;
 
 function ContextMenu(
@@ -36,7 +32,7 @@ function ContextMenu(
     ref?: React.Ref<HTMLDivElement>;
   },
 ): React.ReactElement {
-  const { menu, anchorPointX, anchorPointY, onClose, ...rest } = props;
+  const { menu, anchorPointX, anchorPointY, size, onClose, ...rest } = props;
   const ref = React.useRef<HTMLDivElement>(null);
 
   const handleClickOutside = useCallback(
@@ -61,7 +57,10 @@ function ContextMenu(
 
   return (
     <ContextMenuStyled
-      className="list-group"
+      className={classNames(
+        'context-menu list-group',
+        size === 'sm' && 'list-group-condensed',
+      )}
       ref={ref}
       style={{
         transform: `translate(calc(${anchorPointX}px), calc(${anchorPointY}px))`,

--- a/src/DataTable.tsx
+++ b/src/DataTable.tsx
@@ -278,7 +278,7 @@ function DataTable<T extends Record<string, unknown>>(
     !columns.find((col) => col.accessor === 'selector')
   ) {
     conditionalHooks.push((hooks) =>
-      checkBoxSelectionHook(hooks, id, multipleRowSelection, size),
+      checkBoxSelectionHook(hooks, id, multipleRowSelection),
     );
   }
 
@@ -299,6 +299,7 @@ function DataTable<T extends Record<string, unknown>>(
     selectedFlatRows,
     filterColumns,
     visibleColumns,
+    isResizing,
     state: { pageIndex, pageSize, filters, globalFilter },
     prepareRow,
     getTableProps,
@@ -372,12 +373,14 @@ function DataTable<T extends Record<string, unknown>>(
                 aria-rowcount={data.length}
                 className={classNames(
                   stickyFirstColumn && 'table-sticky-first-column',
+                  isResizing && 'resizing',
                 )}
               >
                 <thead className="bg-gray-light">
                   {headerGroups.map((headerGroup) => (
                     <tr {...headerGroup.getHeaderGroupProps()} role="row">
                       <DataTableContextMenuProvider
+                        size={size}
                         allColumns={allColumns}
                         toggleHideAllColumns={toggleHideAllColumns}
                         toggleHideColumn={toggleHideColumn}

--- a/src/DataTableContextMenuProvider.tsx
+++ b/src/DataTableContextMenuProvider.tsx
@@ -19,6 +19,7 @@ export const DataTableHeaderContextMenu = React.createContext<{
 
 export default function DataTableContextMenuProvider({
   children,
+  size,
   allColumns,
   toggleHideColumn,
   toggleHideAllColumns,
@@ -85,6 +86,7 @@ export default function DataTableContextMenuProvider({
       {renderUsingPortal(
         contextMenu ? (
           <ContextMenu
+            size={size}
             menu={contextMenu.items}
             anchorPointX={contextMenu.positionX}
             anchorPointY={contextMenu.positionY}
@@ -99,6 +101,7 @@ export default function DataTableContextMenuProvider({
 
 DataTableContextMenuProvider.propTypes = {
   children: PropTypes.node,
+  size: PropTypes.string,
   allColumns: PropTypes.any.isRequired,
   toggleHideColumn: PropTypes.func.isRequired,
   toggleHideAllColumns: PropTypes.func.isRequired,

--- a/src/DataTableHeaderCell.tsx
+++ b/src/DataTableHeaderCell.tsx
@@ -87,6 +87,13 @@ const DataTableHeaderCell = React.forwardRef<
     onToggleHideColumn(header.id, false);
   }, [onToggleHideColumn, header.id]);
 
+  const handleMouseDown = useCallback(
+    (event) => {
+      if (onHeaderDragStart && allowDrag) onHeaderDragStart(event, header);
+    },
+    [onHeaderDragStart, header],
+  );
+
   if (!header.isVisible) {
     return (
       <th className="hidden-column">
@@ -115,13 +122,6 @@ const DataTableHeaderCell = React.forwardRef<
       style: getFlexColumnStyles(header),
       title: '',
     },
-    allowDrag
-      ? {
-          onMouseDown(e) {
-            if (onHeaderDragStart) onHeaderDragStart(e, header);
-          },
-        }
-      : {},
   );
 
   return (
@@ -130,15 +130,21 @@ const DataTableHeaderCell = React.forwardRef<
         header.id === DATATABLE_CHECKBOX_SELECTOR_ID
           ? 'icon-only checkbox-selector-cell'
           : 'pr-2',
-        className,
         allowDrag && 'draggable',
+        header.isResizing && 'resizing',
+        className,
       )}
       ref={resolvedRef}
       onContextMenu={handleContextMenuClick}
       {...headerProps}
       {...props}
     >
-      <div className="d-flex w-100 h-100 align-items-center th-content">
+      <div
+        className="d-flex w-100 h-100 align-items-center th-content"
+        onMouseDown={handleMouseDown}
+        role="columnheader"
+        tabIndex={0}
+      >
         <div
           className="flex-grow-1 overflow-hidden"
           style={{

--- a/src/DataTableHelpers.tsx
+++ b/src/DataTableHelpers.tsx
@@ -18,7 +18,6 @@ export const checkBoxSelectionHook = <T extends Record<string, unknown>>(
   hooks: Hooks<T>,
   tableId: string,
   multipleRowSelection,
-  size?: string,
 ) => {
   hooks.visibleColumns.push((columns) => [
     {
@@ -27,7 +26,6 @@ export const checkBoxSelectionHook = <T extends Record<string, unknown>>(
       disableGroupBy: true,
       Cell: ({ row }: CellProps<T>) => (
         <IndeterminateCheckbox
-          size={size}
           {...row.getToggleRowSelectedProps()}
           id={`${tableId}_${DATATABLE_CHECKBOX_SELECTOR_ID}_row"${row.id}`}
         />
@@ -35,7 +33,6 @@ export const checkBoxSelectionHook = <T extends Record<string, unknown>>(
       ...(multipleRowSelection && {
         Header: ({ getToggleAllRowsSelectedProps }: HeaderProps<T>) => (
           <IndeterminateCheckbox
-            size={size}
             {...getToggleAllRowsSelectedProps()}
             id={`${tableId}_${DATATABLE_CHECKBOX_SELECTOR_ID}_header`}
           />

--- a/src/useDataTableInstance.tsx
+++ b/src/useDataTableInstance.tsx
@@ -58,6 +58,10 @@ function useDataTableInstance<T extends Record<string, unknown>>(
     state: { pageIndex, pageSize, filters, globalFilter },
   } = tableInstance;
 
+  const isResizing = headerGroups.find((group) =>
+    group.headers.find((h) => h.isResizing),
+  );
+
   const filterColumns = useMemo(
     () =>
       allColumns
@@ -117,6 +121,7 @@ function useDataTableInstance<T extends Record<string, unknown>>(
     gotoPage,
     setPageSize,
     selectedFlatRows,
+    isResizing,
     state: { pageIndex, pageSize, filters, globalFilter },
     getAllHeadersInAGroup,
   };


### PR DESCRIPTION
## Description

- Fixes issue #114  
- Add the `size` prop in the context menu component that appears when right-clicking on the `DataTable` column headers
- Remove the `size` option from checkboxes used in right-click context menu

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Chrome browser

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
