### PR TITLE
Dependabot: change max open pull requests to 3 each (total 6)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     schedule:
       interval: monthly
     versioning-strategy: increase
+    open-pull-requests-limit: 3
   - package-ecosystem: npm
     directory: '/docs/'
     reviewers:
@@ -18,6 +19,7 @@ updates:
     schedule:
       interval: monthly
     versioning-strategy: increase
+    open-pull-requests-limit: 3
   - package-ecosystem: github-actions
     directory: '/'
     reviewers:


### PR DESCRIPTION
this will prevent it from using up all our deploy preview allowances!
