### PR TITLE
Docs: fix duplicate CSS rule in `_ie11.scss`

### DIFF
--- a/docs/src/assets/css/_ie11.scss
+++ b/docs/src/assets/css/_ie11.scss
@@ -22,8 +22,4 @@
   .navbar-brand svg {
     max-height: 29px;
   }
-
-  .theme-toggle {
-    display: none;
-  }
 }


### PR DESCRIPTION
This rule is already on line 8

Found via SonarQube: https://sonar.trimble.tools/project/issues?id=Modus.trimble%3AModusReactBootstrap&languages=css&open=AYPp9PzTx792aEMoXmPw&resolved=false
