### PR TITLE
Fix Shallow clone SonarQube scan GitHub Action

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 1 * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     name: Sonar Scan Runner
@@ -15,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Run Sonar Scan Action
         uses: sonarsource/sonarqube-scan-action@master


### PR DESCRIPTION
Fixes this issue reported in SonarQube Web UI:

> Shallow clone detected during the analysis. Some files will miss SCM information. This will affect features like auto-assignment of issues. Please configure your build to disable shallow clone.

This matches the format we have for Modus Style guide site which doesn't have this error. https://github.com/trimble-oss/website-modus.trimble.com@main/.github/workflows/sonar-scan.yml
