### PR TITLE
Fix Icon in Message component to accept a valid JSX element or string (modus icon)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Fixes [Cross-realm object access in webpack 5](https://github.com/trimble-oss/modus-react-bootstrap/security/dependabot/48)
 - Fixes [Server-Side Request Forgery in Request](https://github.com/trimble-oss/modus-react-bootstrap/security/dependabot/50)
+- Fixed **Message** component to accept a valid JSX element or a string value which will be automatically rendered as a Modus Icon.
 
 ### BREAKING CHANGES
 

--- a/docs/src/examples/components/Messages.tsx
+++ b/docs/src/examples/components/Messages.tsx
@@ -6,7 +6,7 @@ export const MessagesBasic = `
     message="This is a primary message"
   ></Message>
   <Message
-    icon="help"
+    icon={<i className="modus-icons" aria-hidden="true">help</i>}
     variant="secondary"
     message="This is a secondary message"
   ></Message>

--- a/src/Message.tsx
+++ b/src/Message.tsx
@@ -13,7 +13,7 @@ import { Variant } from './types';
 export interface MessageProps extends React.HTMLProps<HTMLDivElement> {
   variant?: Variant;
   message?: string;
-  icon?: React.ReactElement;
+  icon?: React.ReactElement | string;
   show?: boolean;
 }
 
@@ -32,7 +32,7 @@ const propTypes = {
   label: PropTypes.string,
 
   /**
-   * Icon Element
+   * Icon must be either a valid JSX element or a modus icon, ex: 'info_outlined'. Icon: `ReactElement | string`
    *
    */
   icon: PropTypes.element,
@@ -54,6 +54,14 @@ const Message = forwardRef<HTMLDivElement, MessageProps>(
     { variant, message, icon, show, className, ...props }: MessageProps,
     ref,
   ) => {
+    const iconElement: React.ReactElement | undefined =
+      typeof icon === 'string' ? (
+        <i className="modus-icons" aria-hidden="true">
+          {icon}
+        </i>
+      ) : (
+        icon
+      );
     const msg = (
       <div
         {...props}
@@ -64,7 +72,7 @@ const Message = forwardRef<HTMLDivElement, MessageProps>(
           className,
         )}
       >
-        {icon && <i className="modus-icons">{icon}</i>}
+        {iconElement}
         {message}
         {props.children}
       </div>


### PR DESCRIPTION
The `Message` component now can accept a valid JSX element or a string that will be automatically rendered as a modus icon.

Preview: https://red-mushroom-0133f8210-300.centralus.1.azurestaticapps.net/components/messages/
Fixes #278 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Chrome browser

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
