### PR TITLE
Automate Release Notes Generation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,32 @@
+name-template: 'v$NEXT_PATCH_VERSION 🌈'
+tag-template: 'v$NEXT_PATCH_VERSION'
+prerelease: true
+exclude-labels:
+  - 'skip-changelog'
+categories:
+  - title: '❗ Breaking Changes'
+    labels:
+      - 'breaking-change'
+  - title: '🚀 Features'
+    labels:
+      - 'new-feature'
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '📖 Docs'
+    labels:
+      - 'docs'
+  - title: '📦 Dependencies'
+    labels:
+      - 'dependencies'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- #$NUMBER: $TITLE'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,24 @@
+name: Release notes
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # allow release-drafter/release-drafter to create GitHub releases and add labels to PRs
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    if: github.repository == 'trimble-oss/modus-react-bootstrap'
+
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This automates the Release Notes Generation. It is completely configurable, editable and you can manually change the text at any time.

We are using it on Modus Icons and it works great! https://github.com/trimble-oss/modus-icons/releases

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Tested on the Modus Icons repo.
